### PR TITLE
feat: allow control over mutable tag creation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: 'CHANGELOG.md'
         type: string
+      mutable:
+        description: 'Whether mutable tags should be updated or not'
+        required: false
+        default: 'true'
+        type: string
     outputs:
       url:
         description: 'The URL of the release'
@@ -58,6 +63,7 @@ jobs:
         with:
           path: ${{ inputs.path }}
           draft: ${{ github.event_name == 'pull_request' || github.event.inputs.draft == 'true' }}
+          mutable: ${{ github.event.inputs.mutable == 'true' }}
       - id: comment
         if: github.event_name == 'pull_request' && steps.release.outputs.tag != ''
         uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- an input to control whether mutable tags should be created/updated
 
 ## [1.0.13] - 2023-11-15
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Whether the release should be a draft or not'
     required: true
     default: 'true'
+  mutable:
+    description: 'Whether mutable tags should be updated or not'
+    required: true
+    default: 'true'
   token:
     description: 'The GitHub token'
     required: true

--- a/index.js
+++ b/index.js
@@ -11,9 +11,11 @@ async function run() {
 
     const path = core.getInput('path')
     const draft = core.getInput('draft') === 'true'
+    const mutable = core.getInput('mutable') === 'true'
     const token = core.getInput('token')
     core.info(`Path: ${path}`)
     core.info(`Draft: ${draft}`)
+    core.info(`Mutable: ${mutable}`)
     core.info(`Token: ${token != null ? '***' : null}`)
 
     const octokit = new github.getOctokit(token)
@@ -119,7 +121,7 @@ async function run() {
     core.info(`Release: ${release.html_url}`)
 
     const tags = []
-    if (release.published_at != null) {
+    if (mutable && release.published_at != null) {
       core.info('Updating mutable tags...')
       const suffix = `${version[4] != null ? '-' + version[4] : ''}${version[5] != null ? '+' + version[5] : ''}`
       tags.push(`v${version[1]}.${version[2]}${suffix}`)


### PR DESCRIPTION
Mutable tags for release v1.0.0 would be v1 and v1.0. By disabling mutable tags, you can only create full tags i.e. v1.0.0 and skip creation of v1 and v1.0. This is usually the desired behaviour for repos other than GitHub Actions actions.