### PR TITLE
feat: automatically generate release notes on empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- automatically generate release notes on empty body
 
 ## [1.0.13] - 2023-11-15
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ async function run() {
 
     if (release == null) {
       core.info('Creating release...')
-      const response = (await octokit.rest.repos.createRelease({
+      const options = {
         ...github.context.repo,
         tag_name: tag,
         target_commitish: target,
@@ -92,7 +92,13 @@ async function run() {
         body,
         draft,
         prerelease: version[4] != null
-      })).data
+      }
+      if (body.trim() !== '') {
+        options.body = body
+      } else {
+        options.generate_release_notes = true
+      }
+      const response = (await octokit.rest.repos.createRelease(options)).data
       core.info(JSON.stringify(response, null, 2))
     } else {
       core.info('Updating release...')


### PR DESCRIPTION
As per title, I suggest automating creation of release notes when the changelog entry is empty.